### PR TITLE
fix 소켓(알림)해결, 로그인 유지

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,9 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  errors:
+    unused_import: ignore
 include: package:flutter_lints/flutter.yaml
 
 linter:
@@ -23,6 +26,5 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/controllers/account/login_controller.dart
+++ b/lib/controllers/account/login_controller.dart
@@ -1,9 +1,13 @@
+// Updated login_controller.dart
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:geolocator/geolocator.dart';
 import 'dart:io' show Platform;
+import 'package:tomapto/services/location_service.dart';
+import 'package:tomapto/services/real_time_location_service.dart';
 
 class LoginController {
   final TextEditingController idController = TextEditingController();
@@ -12,7 +16,7 @@ class LoginController {
   final FocusNode passwordFocusNode = FocusNode();
 
   final formKey = GlobalKey<FormState>();
-  bool rememberMe = false;
+  bool rememberMe = true; // 기본값은 true로 설정
   bool obscureText = true;
   bool isLoading = false;
   String errorMessage = '';
@@ -39,7 +43,52 @@ class LoginController {
     });
   }
 
-  // 로그인 메서드
+  // 위치 업데이트를 위한 메서드
+  Future<void> _updateUserLocation() async {
+    try {
+      // 위치 권한 확인
+      LocationPermission permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        permission = await Geolocator.requestPermission();
+
+        if (permission == LocationPermission.denied ||
+            permission == LocationPermission.deniedForever) {
+          print('위치 권한이 거부되었습니다.');
+          return;
+        }
+      }
+
+      // 위치 서비스가 활성화되어 있는지 확인
+      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        print('위치 서비스가 비활성화되어 있습니다.');
+        return;
+      }
+
+      // 현재 위치 가져오기
+      final position = await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.high,
+      );
+
+      // 위치 정보를 서버에 업데이트
+      await LocationService.updateMyLocation(
+        position.latitude,
+        position.longitude,
+        position.heading,
+        position.accuracy,
+      );
+
+      print('로그인 후 위치 업데이트 성공: ${position.latitude}, ${position.longitude}');
+
+      // 실시간 위치 업데이트 서비스 시작
+      final realTimeLocationService = RealTimeLocationService();
+      await realTimeLocationService.startLocationUpdates();
+    } catch (e) {
+      print('위치 업데이트 실패: $e');
+    }
+  }
+
   Future<bool> login(BuildContext context, Function setState) async {
     // 폼 유효성 검사
     if (formKey.currentState?.validate() ?? false) {
@@ -50,7 +99,7 @@ class LoginController {
       });
 
       try {
-        print('로그인 시도: ${idController.text}');
+        print('로그인 시도: ${idController.text}, rememberMe: $rememberMe');
 
         // API 호출
         final responseData = await ApiService.login(
@@ -61,7 +110,21 @@ class LoginController {
 
         // 로그인 성공 처리
         if (responseData['success'] == true) {
-          // 로그인 유지 설정은 ApiService.login에서 이미 처리됨
+          // 토큰과 사용자 ID를 저장합니다.
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setString('token', responseData['token']);
+          await prefs.setString('user_id', responseData['user']['user_id']);
+          await prefs.setBool('remember_me', rememberMe);
+
+          // 중요: 현재 세션 로그인 상태를 항상 true로 설정
+          // 이렇게 하면 remember_me가 false여도 현재 앱 세션에서는 로그인 상태 유지
+          await prefs.setBool('is_logged_in', true);
+
+          print('로그인 성공: 토큰 저장됨. remember_me=$rememberMe, is_logged_in=true');
+
+          // 로그인 성공 후 위치 정보 업데이트
+          await _updateUserLocation();
+
           return true;
         } else {
           // 로그인 실패 처리
@@ -96,9 +159,10 @@ class LoginController {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
     final rememberMe = prefs.getBool('remember_me') ?? false;
+    final isLoggedIn = prefs.getBool('is_logged_in') ?? false;
 
-    // 토큰이 존재하고 로그인 유지가 활성화된 경우 자동 로그인
-    if (token != null && rememberMe) {
+    // 토큰이 있고 로그인 유지가 활성화된 경우 또는 현재 세션에서 로그인한 경우
+    if (token != null && (rememberMe || isLoggedIn)) {
       return true;
     }
     return false;
@@ -169,6 +233,7 @@ class ApiService {
 
         // 로그인 유지 설정 저장
         await prefs.setBool('remember_me', rememberMe);
+        await prefs.setBool('is_logged_in', true); // 현재 세션 로그인 상태 저장
       }
 
       return responseData;
@@ -189,6 +254,7 @@ class ApiService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('token');
     await prefs.remove('user_id');
-    await prefs.remove('remember_me'); // remember_me 설정도 제거
+    await prefs.remove('is_logged_in'); // 현재 세션 로그인 상태 제거
+    // remember_me 설정은 유지하여 다음 로그인 시 사용자 편의성 향상
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:tomapto/pages/map/naver_map.dart';
+import 'package:tomapto/services/real_time_location_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // 네이버 맵 초기화 메서드 선언
 Future<void> init({
@@ -10,6 +12,27 @@ Future<void> init({
 }) async {
   // FlutterNaverMap 인스턴스를 생성하고 init 메서드 호출
   await FlutterNaverMap().init(clientId: clientId, onAuthFailed: onAuthFailed);
+}
+
+// 로그인 상태 확인 및 위치 서비스 시작
+Future<void> initLocationServiceIfLoggedIn() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('token');
+    final rememberMe = prefs.getBool('remember_me') ?? false;
+    final isLoggedIn = prefs.getBool('is_logged_in') ?? false;
+
+    // 로그인 상태인 경우에만 위치 서비스 시작
+    if (token != null && (rememberMe || isLoggedIn)) {
+      final locationService = RealTimeLocationService();
+      if (!locationService.isRunning) {
+        print('앱 시작 시 위치 서비스 초기화 중...');
+        await locationService.startLocationUpdates();
+      }
+    }
+  } catch (e) {
+    print('위치 서비스 초기화 오류: $e');
+  }
 }
 
 void main() async {
@@ -27,8 +50,11 @@ void main() async {
       },
     );
     print('네이버 맵 초기화 성공');
+
+    // 로그인 상태 확인 및 위치 서비스 시작
+    await initLocationServiceIfLoggedIn();
   } catch (e) {
-    print('네이버 맵 초기화 중 오류 발생: $e');
+    print('초기화 중 오류 발생: $e');
   }
 
   runApp(const MyApp());

--- a/lib/pages/favorites/favorites_screen.dart
+++ b/lib/pages/favorites/favorites_screen.dart
@@ -40,11 +40,11 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       // 화면 렌더링 후 모달 표시를 위한 딜레이
       Future.delayed(Duration(milliseconds: 300), () {
         if (mounted) {
-          showLoginServicesModal(context, message: '즐겨찾기는 로그인 후 이용 가능합니다');
+          showLoginServicesModal(context, message: '메뉴는 로그인 후 이용 가능합니다');
         }
       });
     } else if (isLoggedIn) {
-      // 로그인된 경우 즐겨찾기 데이터 가져오기
+      // 로그인된 경우 메뉴뉴 데이터 가져오기
       _fetchFavorites();
     }
   }
@@ -74,7 +74,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     return baseUrl;
   }
 
-  // 즐겨찾기 목록 가져오기
+  // 메뉴뉴 가져오기
   Future<void> _fetchFavorites() async {
     if (!_isLoggedIn) return;
 
@@ -111,7 +111,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
           _isLoading = false;
         });
       } else {
-        print('즐겨찾기 목록 불러오기 실패: ${response.statusCode} - ${response.body}');
+        print('메뉴 불러오기 실패: ${response.statusCode} - ${response.body}');
         setState(() {
           _isLoading = false;
         });
@@ -147,7 +147,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
         _isLoading = false;
       });
     } catch (e) {
-      print('즐겨찾기 목록 불러오기 오류: $e');
+      print('메뉴 불러오기 오류: $e');
       setState(() {
         _isLoading = false;
       });
@@ -251,99 +251,10 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             icon: Icon(Icons.more_vert),
             onPressed: () {
               // 옵션 메뉴 표시
-              _showFavoriteOptions(favorite);
             },
           ),
-          onTap: () {
-            // 선택한 즐겨찾기 위치로 이동하는 기능
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('${favorite['name']} 위치로 이동합니다')),
-            );
-          },
         );
       },
-    );
-  }
-
-  // 즐겨찾기 옵션 메뉴
-  void _showFavoriteOptions(Map<String, dynamic> favorite) {
-    showModalBottomSheet(
-      context: context,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder:
-          (context) => Container(
-            padding: EdgeInsets.symmetric(vertical: 20),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ListTile(
-                  leading: Icon(Icons.map, color: Color(0xFFFB233B)),
-                  title: Text('지도에서 보기'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('지도에서 ${favorite['name']} 위치를 표시합니다'),
-                      ),
-                    );
-                  },
-                ),
-                ListTile(
-                  leading: Icon(Icons.edit, color: Colors.blue),
-                  title: Text('수정하기'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('${favorite['name']} 정보를 수정합니다')),
-                    );
-                  },
-                ),
-                ListTile(
-                  leading: Icon(Icons.delete, color: Colors.red),
-                  title: Text('삭제하기'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    _showDeleteConfirmation(favorite);
-                  },
-                ),
-              ],
-            ),
-          ),
-    );
-  }
-
-  // 삭제 확인 다이얼로그
-  void _showDeleteConfirmation(Map<String, dynamic> favorite) {
-    showDialog(
-      context: context,
-      builder:
-          (context) => AlertDialog(
-            title: Text('즐겨찾기 삭제'),
-            content: Text('\'${favorite['name']}\' 즐겨찾기를 삭제하시겠습니까?'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text('취소'),
-              ),
-              TextButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                  // 삭제 로직 구현
-                  setState(() {
-                    _favorites.removeWhere(
-                      (item) => item['id'] == favorite['id'],
-                    );
-                  });
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('${favorite['name']}이(가) 삭제되었습니다')),
-                  );
-                },
-                child: Text('삭제', style: TextStyle(color: Colors.red)),
-              ),
-            ],
-          ),
     );
   }
 
@@ -363,7 +274,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 40),
             child: Text(
-              '즐겨찾기 기능을 이용하려면 로그인이 필요합니다',
+              '메뉴 기능을 이용하려면 로그인이 필요합니다',
               style: TextStyle(color: Colors.grey[600]),
               textAlign: TextAlign.center,
             ),

--- a/lib/pages/friends/friends_list_screen.dart
+++ b/lib/pages/friends/friends_list_screen.dart
@@ -7,11 +7,13 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'dart:io' show Platform;
 import 'package:tomapto/modal/friends_show.dart';
 import 'package:tomapto/modal/friends_setting_modal.dart';
-import 'package:tomapto/modal/login_services.dart'; // 로그인 서비스 모달 추가
+import 'package:tomapto/modal/login_services.dart';
 import 'package:tomapto/widgets/navbar.dart';
 import 'package:tomapto/pages/friends/friends_add.dart';
 import 'package:tomapto/services/socket_service.dart';
-import 'package:tomapto/services/token_service.dart'; // 토큰 서비스 추가
+import 'package:tomapto/services/token_service.dart';
+import 'package:tomapto/pages/profile/login.dart';
+import 'package:tomapto/services/real_time_location_service.dart';
 
 class FriendScreen extends StatefulWidget {
   @override
@@ -55,6 +57,9 @@ class _FriendScreenState extends State<FriendScreen> {
         _fetchFriendsFromServer();
         _fetchFriendRequestsCount();
         _fetchLocationSharingStatus();
+
+        // 실시간 위치 업데이트 서비스 확인 및 필요시 시작
+        _checkAndStartLocationService();
       } else {
         // 로그인되지 않은 경우에만 화면이 로드된 후 실행되도록 WidgetsBinding 사용
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -79,21 +84,39 @@ class _FriendScreenState extends State<FriendScreen> {
     try {
       final prefs = await SharedPreferences.getInstance();
       final token = prefs.getString('token');
+      final isLoggedIn = prefs.getBool('is_logged_in') ?? false;
+
+      // 토큰이 없는 경우
+      if (token == null) {
+        print('토큰이 없습니다. 로그인이 필요합니다.');
+        return false;
+      }
+
+      // 현재 세션에서 로그인한 경우 (is_logged_in이 true)
+      if (isLoggedIn) {
+        // 토큰 만료 여부만 확인
+        if (TokenService.isTokenExpired(token)) {
+          // 토큰이 만료된 경우 로그아웃 처리
+          await _logout();
+          return false;
+        }
+        return true; // 현재 세션 로그인 상태이고 토큰이 유효하면 로그인됨
+      }
+
+      // remember_me 설정이 활성화된 경우
       final rememberMe = prefs.getBool('remember_me') ?? false;
-
-      // 토큰이 없거나 자동 로그인이 비활성화된 경우
-      if (token == null || !rememberMe) {
-        return false;
+      if (rememberMe) {
+        // 토큰 유효성 확인
+        if (TokenService.isTokenExpired(token)) {
+          // 토큰이 만료된 경우 로그아웃 처리
+          await _logout();
+          return false;
+        }
+        return true; // 자동 로그인 설정이 활성화되고 토큰이 유효하면 로그인됨
       }
 
-      // 토큰 유효성 확인
-      if (TokenService.isTokenExpired(token)) {
-        // 토큰이 만료된 경우 로그아웃 처리
-        await _logout();
-        return false;
-      }
-
-      return true;
+      // 현재 세션 로그인도 아니고 자동 로그인도 비활성화된 경우
+      return false;
     } catch (e) {
       print('로그인 상태 확인 오류: $e');
       return false;
@@ -124,8 +147,24 @@ class _FriendScreenState extends State<FriendScreen> {
 
   // 바텀 네비게이션 바 탭 변경 처리
   void _handleNavIndexChanged(int index) {
-    setState(() {
-      _currentNavIndex = index;
+    // 페이지 이동 전 토큰 유효성 다시 확인
+    _checkLoginStatus().then((isLoggedIn) {
+      if (!isLoggedIn && index != 0) {
+        // 홈 화면이 아닌 경우 로그인 필요
+        setState(() {
+          _isLoggedIn = false;
+          _hasShownLoginModal = false; // 다시 모달 표시 가능하도록 설정
+        });
+        _showLoginModalIfNeeded();
+        return;
+      }
+
+      setState(() {
+        _currentNavIndex = index;
+      });
+
+      // 여기서 실제 탭 전환 로직 구현
+      // ...
     });
   }
 
@@ -152,6 +191,22 @@ class _FriendScreenState extends State<FriendScreen> {
 
     // 다른 플랫폼이거나 이미 localhost가 아닌 경우 원래 URL 반환
     return baseUrl;
+  }
+
+  Future<void> _checkAndStartLocationService() async {
+    try {
+      // 위치 권한 확인
+      final hasPermission =
+          await RealTimeLocationService().startLocationUpdates();
+
+      if (hasPermission) {
+        print('실시간 위치 업데이트 서비스 시작됨');
+      } else {
+        print('실시간 위치 업데이트 서비스 시작 실패');
+      }
+    } catch (e) {
+      print('위치 업데이트 서비스 초기화 중 오류 발생: $e');
+    }
   }
 
   // 소켓 초기화 함수
@@ -239,9 +294,28 @@ class _FriendScreenState extends State<FriendScreen> {
           '친구 위치 업데이트: ${data['user_id']} - lat: ${data['latitude']}, lng: ${data['longitude']}',
         );
       });
+
+      // 친구 상태 변경 리스너 등록
+      socketService.onFriendStatusChange.listen((data) {
+        // 친구 상태 변경 처리
+        print('친구 상태 변경: ${data['user_id']} - 온라인: ${data['isOnline']}');
+        _refreshFriendsStatus(data);
+      });
     } catch (e) {
       print('소켓 서비스 초기화 오류: $e');
     }
+  }
+
+  // 특정 친구의 상태 업데이트
+  void _refreshFriendsStatus(Map<String, dynamic> statusData) {
+    setState(() {
+      for (var i = 0; i < friends.length; i++) {
+        if (friends[i]['id'] == statusData['user_id']) {
+          friends[i]['isOnline'] = statusData['isOnline'];
+          break;
+        }
+      }
+    });
   }
 
   // 서버에서 친구 목록 가져오기
@@ -258,6 +332,25 @@ class _FriendScreenState extends State<FriendScreen> {
         setState(() {
           _isLoggedIn = false;
         });
+        return;
+      }
+
+      // 토큰 만료 확인
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다');
+        setState(() {
+          _isLoggedIn = false;
+        });
+        // 로그아웃 처리
+        await _logout();
+
+        // 로그인 페이지로 리디렉션
+        if (mounted) {
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(builder: (context) => const LoginPage()),
+          );
+        }
         return;
       }
 
@@ -290,6 +383,14 @@ class _FriendScreenState extends State<FriendScreen> {
         });
         // 로그아웃 처리
         await _logout();
+
+        // 로그인 페이지로 리디렉션
+        if (mounted) {
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(builder: (context) => const LoginPage()),
+          );
+        }
       } else {
         print('친구 목록 불러오기 실패: ${response.statusCode} - ${response.body}');
       }
@@ -312,6 +413,16 @@ class _FriendScreenState extends State<FriendScreen> {
         setState(() {
           _isLoggedIn = false;
         });
+        return;
+      }
+
+      // 토큰 만료 확인
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다');
+        setState(() {
+          _isLoggedIn = false;
+        });
+        await _logout();
         return;
       }
 
@@ -366,6 +477,16 @@ class _FriendScreenState extends State<FriendScreen> {
         setState(() {
           _isLoggedIn = false;
         });
+        return;
+      }
+
+      // 토큰 만료 확인
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다');
+        setState(() {
+          _isLoggedIn = false;
+        });
+        await _logout();
         return;
       }
 

--- a/lib/pages/profile/login.dart
+++ b/lib/pages/profile/login.dart
@@ -200,7 +200,11 @@ class _LoginPageState extends State<LoginPage> {
 
   // 로그인 처리
   // login.dart 파일의 _login() 함수 수정
+  // 로그인 처리
   Future<void> _login() async {
+    // 키보드 숨기기
+    FocusScope.of(context).unfocus();
+
     // _controller.login() 함수에 rememberMe 값을 전달
     final success = await _controller.login(context, setState);
     if (success && mounted) {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -40,8 +40,9 @@ class ApiService {
   // 로그인 요청 메소드
   static Future<Map<String, dynamic>> login(
     String userId,
-    String password,
-  ) async {
+    String password, [
+    bool rememberMe = true, // 기본값 true로 설정 (선택적 파라미터) - 쉼표 제거
+  ]) async {
     try {
       // API 기본 URL 가져오기
       final apiBaseUrl = getApiBaseUrl();
@@ -51,7 +52,11 @@ class ApiService {
       final response = await http.post(
         Uri.parse('$apiBaseUrl/account/login'),
         headers: {'Content-Type': 'application/json'},
-        body: json.encode({'user_id': userId, 'user_password': password}),
+        body: json.encode({
+          'user_id': userId,
+          'user_password': password,
+          'remember_me': rememberMe, // rememberMe 값 서버에 전송
+        }),
       );
 
       // 응답 로깅 (디버깅용)
@@ -62,15 +67,13 @@ class ApiService {
       final responseData = json.decode(response.body);
 
       if (response.statusCode == 200) {
-        // 로그인 성공 시 토큰 저장
+        // 로그인 성공 시 토큰과 사용자 정보 저장
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('token', responseData['token']);
         await prefs.setString('user_id', responseData['user']['user_id']);
 
-        // 로그인 유지 체크 시 추가 설정
-        if (responseData['remember_me'] ?? false) {
-          await prefs.setBool('remember_me', true);
-        }
+        // remember_me 값 저장 - 앱 종료 후에도 로그인 상태 유지할지 결정
+        await prefs.setBool('remember_me', rememberMe);
       }
 
       return responseData;
@@ -148,7 +151,7 @@ class ApiService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove('token');
       await prefs.remove('user_id');
-      await prefs.remove('remember_me');
+      // remember_me 설정은 유지 (사용자 편의성 향상)
 
       // 응답 파싱 (실패하더라도 로컬에서는 로그아웃 처리)
       try {
@@ -164,7 +167,7 @@ class ApiService {
         final prefs = await SharedPreferences.getInstance();
         await prefs.remove('token');
         await prefs.remove('user_id');
-        await prefs.remove('remember_me');
+        // remember_me 설정은 유지 (사용자 편의성 향상)
 
         return {'success': true, 'message': '서버 연결 오류, 로컬에서 로그아웃 처리 완료'};
       } catch (e) {

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:io' show Platform;
 import 'package:geolocator/geolocator.dart';
 import 'dart:async';
+import 'package:tomapto/services/token_service.dart';
 
 class LocationService {
   static String getApiBaseUrl() {
@@ -50,8 +51,24 @@ class LocationService {
         return false;
       }
 
+      // 토큰 유효성 검사
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 다시 로그인해주세요.');
+        return false;
+      }
+
       final apiBaseUrl = getApiBaseUrl();
-      print('위치 업데이트 요청: $latitude, $longitude');
+      print('위치 업데이트 요청: $latitude, $longitude, API: $apiBaseUrl');
+
+      // 요청 데이터 구성
+      Map<String, dynamic> requestData = {
+        'latitude': latitude,
+        'longitude': longitude,
+      };
+
+      // 선택적 필드는 null이 아닐 때만 추가
+      if (heading != null) requestData['heading'] = heading;
+      if (accuracy != null) requestData['accuracy'] = accuracy;
 
       final response = await http.post(
         Uri.parse('$apiBaseUrl/location/update'),
@@ -59,17 +76,19 @@ class LocationService {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer $token',
         },
-        body: json.encode({
-          'latitude': latitude,
-          'longitude': longitude,
-          'heading': heading,
-          'accuracy': accuracy,
-        }),
+        body: json.encode(requestData),
       );
+
+      // 응답 로깅 추가
+      print('위치 업데이트 응답 코드: ${response.statusCode}');
+      print('위치 업데이트 응답 데이터: ${response.body}');
 
       if (response.statusCode == 200) {
         print('위치 업데이트 성공: $latitude, $longitude');
         return true;
+      } else if (response.statusCode == 401) {
+        print('위치 업데이트 실패: 인증 오류 - 다시 로그인이 필요합니다');
+        return false;
       } else {
         print('위치 업데이트 실패: ${response.statusCode} - ${response.body}');
         return false;
@@ -91,6 +110,12 @@ class LocationService {
 
       if (token == null) {
         print('로그인이 필요합니다');
+        return null;
+      }
+
+      // 토큰 유효성 검사
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 다시 로그인해주세요.');
         return null;
       }
 
@@ -125,6 +150,12 @@ class LocationService {
 
       if (token == null) {
         print('로그인이 필요합니다');
+        return false;
+      }
+
+      // 토큰 유효성 검사
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 다시 로그인해주세요.');
         return false;
       }
 
@@ -174,6 +205,12 @@ class LocationService {
         return false;
       }
 
+      // 토큰 유효성 검사
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 다시 로그인해주세요.');
+        return false;
+      }
+
       final apiBaseUrl = getApiBaseUrl();
       final response = await http.post(
         Uri.parse('$apiBaseUrl/location/end-sharing'),
@@ -206,6 +243,12 @@ class LocationService {
 
       if (token == null) {
         print('로그인이 필요합니다');
+        return null;
+      }
+
+      // 토큰 유효성 검사
+      if (TokenService.isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 다시 로그인해주세요.');
         return null;
       }
 
@@ -247,144 +290,6 @@ class LocationService {
       return serviceEnabled;
     } catch (e) {
       print('위치 권한 확인 오류: $e');
-      return false;
-    }
-  }
-}
-
-// 실시간 위치 서비스 클래스
-class RealTimeLocationService {
-  // 싱글톤 인스턴스
-  static final RealTimeLocationService _instance =
-      RealTimeLocationService._internal();
-  factory RealTimeLocationService() => _instance;
-  RealTimeLocationService._internal();
-
-  // 위치 스트림 구독
-  StreamSubscription<Position>? _positionStreamSubscription;
-
-  // 위치 갱신 상태
-  bool _isRunning = false;
-
-  // 위치 업데이트 간격 (초)
-  final int _updateIntervalSeconds = 30; // 기본 30초마다 갱신
-
-  // 현재 위치 스트림 설정
-  LocationSettings get _locationSettings => LocationSettings(
-    accuracy: LocationAccuracy.high,
-    distanceFilter: 10, // 10m 이상 이동했을 때 이벤트 발생
-    timeLimit: Duration(seconds: _updateIntervalSeconds),
-  );
-
-  // 위치 업데이트 시작
-  Future<bool> startLocationUpdates() async {
-    // 이미 실행 중이면 중복 실행 방지
-    if (_isRunning) return true;
-
-    try {
-      // 위치 권한 확인
-      bool hasPermission = await LocationService.checkLocationPermission();
-      if (!hasPermission) {
-        print('위치 권한이 없거나 위치 서비스가 비활성화되어 있습니다.');
-        return false;
-      }
-
-      // 스트림 구독 시작
-      _positionStreamSubscription = Geolocator.getPositionStream(
-        locationSettings: _locationSettings,
-      ).listen(
-        _onPositionUpdate,
-        onError: (error) {
-          print('위치 스트림 오류: $error');
-          _isRunning = false;
-        },
-        onDone: () {
-          print('위치 스트림 종료');
-          _isRunning = false;
-        },
-      );
-
-      _isRunning = true;
-      print('실시간 위치 업데이트 서비스 시작됨');
-
-      // 즉시 한 번 업데이트 실행
-      _updateCurrentLocation();
-
-      return true;
-    } catch (e) {
-      print('위치 업데이트 서비스 시작 오류: $e');
-      _isRunning = false;
-      return false;
-    }
-  }
-
-  // 위치 업데이트 중지
-  Future<void> stopLocationUpdates() async {
-    if (_positionStreamSubscription != null) {
-      await _positionStreamSubscription!.cancel();
-      _positionStreamSubscription = null;
-    }
-    _isRunning = false;
-    print('실시간 위치 업데이트 서비스 중지됨');
-  }
-
-  // 위치 변경 이벤트 핸들러
-  void _onPositionUpdate(Position position) async {
-    print('새 위치 수신: ${position.latitude}, ${position.longitude}');
-
-    // 서버에 위치 업데이트 전송
-    try {
-      bool success = await LocationService.updateMyLocation(
-        position.latitude,
-        position.longitude,
-        position.heading,
-        position.accuracy,
-      );
-
-      if (success) {
-        print('서버에 위치 업데이트 성공');
-      } else {
-        print('서버에 위치 업데이트 실패');
-      }
-    } catch (e) {
-      print('위치 업데이트 중 오류 발생: $e');
-    }
-  }
-
-  // 현재 위치 즉시 업데이트
-  Future<void> _updateCurrentLocation() async {
-    try {
-      Position position = await Geolocator.getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.high,
-      );
-
-      // 수동으로 핸들러 호출
-      _onPositionUpdate(position);
-    } catch (e) {
-      print('현재 위치 가져오기 실패: $e');
-    }
-  }
-
-  // 현재 서비스 실행 상태 반환
-  bool get isRunning => _isRunning;
-
-  // 수동으로 위치 업데이트 요청
-  Future<bool> updateLocationOnce() async {
-    try {
-      Position position = await Geolocator.getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.high,
-      );
-
-      bool success = await LocationService.updateMyLocation(
-        position.latitude,
-        position.longitude,
-        position.heading,
-        position.accuracy,
-      );
-
-      return success;
-    } catch (e) {
-      print('위치 업데이트 실패: $e');
       return false;
     }
   }

--- a/lib/services/real_time_location_service.dart
+++ b/lib/services/real_time_location_service.dart
@@ -1,7 +1,9 @@
-// services/real_time_location_service.dart
+// Enhanced real_time_location_service.dart
 import 'dart:async';
 import 'package:geolocator/geolocator.dart';
 import 'package:tomapto/services/location_service.dart';
+import 'package:tomapto/services/socket_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class RealTimeLocationService {
   // 싱글톤 인스턴스
@@ -17,12 +19,15 @@ class RealTimeLocationService {
   bool _isRunning = false;
 
   // 위치 업데이트 간격 (초)
-  final int _updateIntervalSeconds = 30; // 기본 30초마다 갱신
+  final int _updateIntervalSeconds = 20; // 30초 -> 20초로 변경 (더 자주 업데이트)
+
+  // 백그라운드 작업 타이머
+  Timer? _backgroundTimer;
 
   // 현재 위치 스트림 설정
   LocationSettings get _locationSettings => LocationSettings(
     accuracy: LocationAccuracy.high,
-    distanceFilter: 10, // 10m 이상 이동했을 때 이벤트 발생
+    distanceFilter: 5, // 10m -> 5m로 변경 (더 작은 거리 변화에도 업데이트)
     timeLimit: Duration(seconds: _updateIntervalSeconds),
   );
 
@@ -32,11 +37,25 @@ class RealTimeLocationService {
     if (_isRunning) return true;
 
     try {
+      // 로그인 상태 확인
+      final prefs = await SharedPreferences.getInstance();
+      final token = prefs.getString('token');
+      if (token == null) {
+        print('위치 업데이트를 시작하려면 로그인이 필요합니다.');
+        return false;
+      }
+
       // 위치 권한 확인
       bool hasPermission = await LocationService.checkLocationPermission();
       if (!hasPermission) {
         print('위치 권한이 없거나 위치 서비스가 비활성화되어 있습니다.');
         return false;
+      }
+
+      // 소켓 서비스 초기화 - 위치 업데이트 전에 소켓 연결 확인
+      final socketService = SocketService();
+      if (!socketService.isConnected) {
+        await socketService.initSocket();
       }
 
       // 스트림 구독 시작
@@ -60,6 +79,9 @@ class RealTimeLocationService {
       // 즉시 한 번 업데이트 실행
       _updateCurrentLocation();
 
+      // 백그라운드 타이머 시작 (앱이 백그라운드에 있을 때도 주기적으로 위치 업데이트)
+      _startBackgroundTimer();
+
       return true;
     } catch (e) {
       print('위치 업데이트 서비스 시작 오류: $e');
@@ -68,22 +90,73 @@ class RealTimeLocationService {
     }
   }
 
+  // 백그라운드 타이머 시작
+  void _startBackgroundTimer() {
+    // 기존 타이머가 있으면 취소
+    _backgroundTimer?.cancel();
+
+    // 백그라운드에서도 주기적으로 위치를 업데이트하기 위한 타이머
+    _backgroundTimer = Timer.periodic(
+      Duration(minutes: 5), // 5분마다
+      (timer) async {
+        // 로그인 상태인지 확인
+        final prefs = await SharedPreferences.getInstance();
+        final token = prefs.getString('token');
+        if (token == null) {
+          timer.cancel();
+          stopLocationUpdates();
+          return;
+        }
+
+        // 백그라운드에서 위치 업데이트
+        try {
+          await updateLocationOnce();
+        } catch (e) {
+          print('백그라운드 위치 업데이트 오류: $e');
+        }
+      },
+    );
+  }
+
   // 위치 업데이트 중지
   Future<void> stopLocationUpdates() async {
     if (_positionStreamSubscription != null) {
       await _positionStreamSubscription!.cancel();
       _positionStreamSubscription = null;
     }
+
+    // 백그라운드 타이머 취소
+    _backgroundTimer?.cancel();
+    _backgroundTimer = null;
+
     _isRunning = false;
     print('실시간 위치 업데이트 서비스 중지됨');
   }
 
   // 위치 변경 이벤트 핸들러
   void _onPositionUpdate(Position position) async {
-    print('새 위치 수신: ${position.latitude}, ${position.longitude}');
+    print(
+      '새 위치 수신: ${position.latitude}, ${position.longitude}, 정확도: ${position.accuracy}, 방향: ${position.heading}',
+    );
 
     // 서버에 위치 업데이트 전송
     try {
+      // 소켓을 통한 실시간 위치 업데이트
+      final socketService = SocketService();
+      if (!socketService.isConnected) {
+        await socketService.initSocket();
+      }
+
+      if (socketService.isConnected) {
+        socketService.sendLocationUpdate(
+          position.latitude,
+          position.longitude,
+          position.heading,
+          position.accuracy,
+        );
+      }
+
+      // REST API를 통한 위치 업데이트 (서버 DB 저장용)
       bool success = await LocationService.updateMyLocation(
         position.latitude,
         position.longitude,
@@ -98,6 +171,14 @@ class RealTimeLocationService {
       }
     } catch (e) {
       print('위치 업데이트 중 오류 발생: $e');
+
+      // 오류 발생 시 소켓 재연결 시도
+      try {
+        final socketService = SocketService();
+        await socketService.reconnect();
+      } catch (reconnectError) {
+        print('소켓 재연결 시도 중 오류: $reconnectError');
+      }
     }
   }
 
@@ -121,9 +202,32 @@ class RealTimeLocationService {
   // 수동으로 위치 업데이트 요청
   Future<bool> updateLocationOnce() async {
     try {
+      // 로그인 상태 확인
+      final prefs = await SharedPreferences.getInstance();
+      final token = prefs.getString('token');
+      if (token == null) {
+        print('위치 업데이트를 위해서는 로그인이 필요합니다.');
+        return false;
+      }
+
       Position position = await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.high,
       );
+
+      // 소켓을 통한 실시간 위치 업데이트
+      final socketService = SocketService();
+      if (!socketService.isConnected) {
+        await socketService.initSocket();
+      }
+
+      if (socketService.isConnected) {
+        socketService.sendLocationUpdate(
+          position.latitude,
+          position.longitude,
+          position.heading,
+          position.accuracy,
+        );
+      }
 
       bool success = await LocationService.updateMyLocation(
         position.latitude,

--- a/lib/services/socket_service.dart
+++ b/lib/services/socket_service.dart
@@ -24,6 +24,8 @@ class SocketService {
       StreamController<Map<String, dynamic>>.broadcast();
   final _locationSharingStoppedController =
       StreamController<Map<String, dynamic>>.broadcast();
+  final _friendStatusChangeController =
+      StreamController<Map<String, dynamic>>.broadcast();
 
   // 이벤트 스트림 게터
   Stream<Map<String, dynamic>> get onFriendRequest =>
@@ -36,36 +38,48 @@ class SocketService {
       _locationSharingStartedController.stream;
   Stream<Map<String, dynamic>> get onLocationSharingStopped =>
       _locationSharingStoppedController.stream;
+  Stream<Map<String, dynamic>> get onFriendStatusChange =>
+      _friendStatusChangeController.stream;
 
   // 소켓 서버 URL 가져오기
   String _getSocketUrl() {
-    String baseUrl = dotenv.env['SOCKET_URL'] ?? 'http://localhost:8080';
-    String? localIp = dotenv.env['LOCAL_IP'];
+    // 먼저 SOCKET_URL 환경변수를 확인
+    String socketUrl = dotenv.env['SOCKET_URL'] ?? '';
 
-    // 안드로이드 에뮬레이터에서 실행 중인 경우
-    if (Platform.isAndroid) {
-      // localhost를 사용 중이고 LOCAL_IP가 설정되어 있다면
-      if (baseUrl.contains('localhost') &&
-          localIp != null &&
-          localIp.isNotEmpty) {
-        // localhost를 LOCAL_IP로 대체
-        return baseUrl.replaceAll('localhost', localIp);
-      }
+    // SOCKET_URL이 없으면 API_BASE_URL에서 파생
+    if (socketUrl.isEmpty) {
+      String baseUrl =
+          dotenv.env['API_BASE_URL'] ?? 'http://localhost:8080/api';
+      // API URL에서 /api 부분 제거
+      socketUrl = baseUrl.replaceAll('/api', '');
 
-      // 에뮬레이터 특정 주소 처리
-      if (baseUrl.contains('localhost')) {
-        return baseUrl.replaceAll('localhost', '10.0.2.2');
+      String? localIp = dotenv.env['LOCAL_IP'];
+
+      // 안드로이드 에뮬레이터에서 실행 중인 경우
+      if (Platform.isAndroid) {
+        // localhost를 사용 중이고 LOCAL_IP가 설정되어 있다면
+        if (socketUrl.contains('localhost') &&
+            localIp != null &&
+            localIp.isNotEmpty) {
+          // localhost를 LOCAL_IP로 대체
+          socketUrl = socketUrl.replaceAll('localhost', localIp);
+        }
+
+        // 에뮬레이터 특정 주소 처리
+        if (socketUrl.contains('localhost')) {
+          socketUrl = socketUrl.replaceAll('localhost', '10.0.2.2');
+        }
       }
     }
 
-    // 다른 플랫폼이거나 이미 localhost가 아닌 경우 원래 URL 반환
-    return baseUrl;
+    print('소켓 URL: $socketUrl');
+    return socketUrl;
   }
 
   // 소켓 연결 초기화
   Future<void> initSocket() async {
-    if (_socket != null) {
-      print('소켓이 이미 초기화되어 있습니다.');
+    if (_socket != null && _socket!.connected) {
+      print('소켓이 이미 연결되어 있습니다.');
       return;
     }
 
@@ -82,13 +96,21 @@ class SocketService {
       final socketUrl = _getSocketUrl();
       print('소켓 서버 연결 시도: $socketUrl');
 
+      // 소켓 디버깅 로그 활성화 부분 제거
+      // IO.Socket.enableLogging = true; // 이 부분 제거
+
       // 소켓 객체 생성 및 설정
       _socket = IO.io(
         socketUrl,
         IO.OptionBuilder()
-            .setTransports(['websocket'])
+            .setTransports(['websocket', 'polling']) // polling 폴백 추가
             .disableAutoConnect()
-            .setExtraHeaders({'Authorization': 'Bearer $token'})
+            .setExtraHeaders({'Authorization': 'Bearer $token'}) // 헤더에도 토큰 추가
+            .setAuth({'token': token}) // auth 객체에 토큰 전달
+            .enableForceNew() // 새 연결 강제
+            .enableReconnection() // 재연결 활성화
+            .setReconnectionAttempts(5) // 최대 5번 재시도
+            .setReconnectionDelay(3000) // 3초마다 재연결 시도
             .build(),
       );
 
@@ -97,6 +119,8 @@ class SocketService {
 
       // 소켓 연결
       _socket!.connect();
+
+      print('소켓 연결 초기화 성공');
     } catch (e) {
       print('소켓 초기화 오류: $e');
     }
@@ -106,6 +130,14 @@ class SocketService {
   void _setupSocketListeners() {
     _socket!.on('connect', (_) {
       print('소켓 연결 성공! ID: ${_socket!.id}');
+    });
+
+    _socket!.on('connect_error', (error) {
+      print('소켓 연결 오류: $error');
+    });
+
+    _socket!.on('connect_timeout', (_) {
+      print('소켓 연결 시간 초과');
     });
 
     _socket!.on('disconnect', (_) {
@@ -145,6 +177,17 @@ class SocketService {
       print('위치 공유 종료 수신: $data');
       _locationSharingStoppedController.add(Map<String, dynamic>.from(data));
     });
+
+    // 친구 상태 변경 이벤트 (온라인/오프라인)
+    _socket!.on('friend_status_change', (data) {
+      print('친구 상태 변경 수신: $data');
+      _friendStatusChangeController.add(Map<String, dynamic>.from(data));
+    });
+
+    // 연결 성공 이벤트
+    _socket!.on('connect_success', (data) {
+      print('연결 성공 이벤트: $data');
+    });
   }
 
   // 친구 요청 전송
@@ -155,6 +198,7 @@ class SocketService {
     }
 
     _socket!.emit('send_friend_request', {'recipient_id': recipientId});
+    print('친구 요청 전송: $recipientId');
   }
 
   // 친구 요청 수락
@@ -165,6 +209,7 @@ class SocketService {
     }
 
     _socket!.emit('accept_friend_request', {'request_id': requestId});
+    print('친구 요청 수락: $requestId');
   }
 
   // 친구 요청 거절
@@ -175,6 +220,7 @@ class SocketService {
     }
 
     _socket!.emit('reject_friend_request', {'request_id': requestId});
+    print('친구 요청 거절: $requestId');
   }
 
   // 위치 공유 시작 (durationMinutes가 null이면 무제한 공유)
@@ -189,6 +235,8 @@ class SocketService {
       'friend_id': friendId,
       'duration_minutes': durationMinutes, // null일 경우 무제한
     });
+
+    print('위치 공유 시작: $friendId, 기간: ${durationMinutes ?? "무제한"}');
   }
 
   // 위치 공유 종료
@@ -200,6 +248,7 @@ class SocketService {
 
     // 소켓으로 위치 공유 종료 이벤트 전송
     _socket!.emit('stop_location_sharing', {'friend_id': friendId});
+    print('위치 공유 종료: $friendId');
   }
 
   // 위치 업데이트 전송
@@ -210,16 +259,20 @@ class SocketService {
     double? accuracy,
   ) {
     if (_socket == null || !_socket!.connected) {
-      print('소켓이 연결되어 있지 않습니다.');
+      print('소켓이 연결되어 있지 않습니다. 위치 업데이트를 보낼 수 없습니다.');
+      initSocket(); // 연결이 끊어졌으면 다시 연결 시도
       return;
     }
 
-    _socket!.emit('update_location', {
-      'latitude': latitude,
-      'longitude': longitude,
-      'heading': heading,
-      'accuracy': accuracy,
-    });
+    // 모든 속성이 null이 아닌지 확인
+    Map<String, dynamic> data = {'latitude': latitude, 'longitude': longitude};
+
+    // 선택적 속성은 null이 아닐 때만 추가
+    if (heading != null) data['heading'] = heading;
+    if (accuracy != null) data['accuracy'] = accuracy;
+
+    print('위치 업데이트 전송: $data');
+    _socket!.emit('update_location', data);
   }
 
   // 소켓 연결 해제
@@ -239,8 +292,15 @@ class SocketService {
     _locationUpdateController.close();
     _locationSharingStartedController.close();
     _locationSharingStoppedController.close();
+    _friendStatusChangeController.close();
   }
 
   // 연결 상태 확인
   bool get isConnected => _socket?.connected ?? false;
+
+  // 재연결 시도
+  Future<void> reconnect() async {
+    disconnect();
+    await initSocket();
+  }
 }

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -1,7 +1,9 @@
+// Enhanced token_service.dart
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tomapto/pages/profile/login.dart';
+import 'package:tomapto/services/real_time_location_service.dart';
 
 class TokenService {
   // JWT 토큰 디코딩 메서드
@@ -10,6 +12,7 @@ class TokenService {
       // JWT 토큰 형식: xxxxx.yyyyy.zzzzz
       final parts = token.split('.');
       if (parts.length != 3) {
+        print('토큰 형식이 유효하지 않습니다.');
         return null;
       }
 
@@ -18,6 +21,9 @@ class TokenService {
       var normalized = base64Url.normalize(payload);
       var resp = utf8.decode(base64Url.decode(normalized));
       final payloadMap = json.decode(resp);
+
+      // 디버깅용 로그
+      print('파싱된 토큰 데이터: ${payloadMap.keys.join(', ')}');
 
       return payloadMap;
     } catch (e) {
@@ -32,23 +38,30 @@ class TokenService {
       final Map<String, dynamic>? decodedToken = parseJwt(token);
 
       if (decodedToken == null) {
+        print('토큰 파싱 실패');
         return true; // 파싱 실패 시 만료된 것으로 간주
       }
 
       // JWT의 exp 클레임(만료 시간) 확인
       final exp = decodedToken['exp'];
       if (exp == null) {
-        return true; // exp 필드가 없으면 만료된 것으로 간주
+        print('토큰에 만료 시간(exp)이 없습니다. 토큰 내용: $decodedToken');
+        return false; // exp 필드가 없으면 만료되지 않은 것으로 간주
       }
 
       // 만료 시간은 초 단위로 저장됨, 현재 시간은 밀리초 단위이므로 변환 필요
       final expiry = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
       final now = DateTime.now();
 
-      return now.isAfter(expiry);
+      final isExpired = now.isAfter(expiry);
+
+      // 디버깅용 로그
+      print('토큰 만료시간: $expiry, 현재시간: $now, 만료됨: $isExpired');
+
+      return isExpired;
     } catch (e) {
       print('토큰 만료 확인 오류: $e');
-      return true; // 오류 발생 시 만료된 것으로 간주
+      return false; // 오류 발생 시에도 토큰을 유효한 것으로 간주
     }
   }
 
@@ -56,30 +69,63 @@ class TokenService {
   static Future<bool> validateToken(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
+    final isLoggedIn = prefs.getBool('is_logged_in') ?? false;
 
     // 토큰이 없는 경우
-    if (token == null || token.isEmpty) {
+    if (token == null) {
+      print('토큰이 없습니다.');
       _redirectToLogin(context);
       return false;
     }
 
-    // 토큰이 만료된 경우
-    if (isTokenExpired(token)) {
-      print('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
-      await _logout();
-      _redirectToLogin(context);
-      return false;
+    // 현재 세션에서 로그인한 경우는 remember_me 설정과 관계없이 로그인 상태 유지
+    if (isLoggedIn) {
+      // 토큰이 만료된 경우만 확인
+      if (isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
+        await _logout();
+        _redirectToLogin(context);
+        return false;
+      }
+      return true; // 현재 세션 로그인 + 토큰 유효 = 로그인 상태 유지
     }
 
-    return true; // 토큰이 유효함
+    // 자동 로그인(remember_me)이 활성화된 경우
+    final rememberMe = prefs.getBool('remember_me') ?? false;
+    if (rememberMe) {
+      // 토큰이 만료된 경우
+      if (isTokenExpired(token)) {
+        print('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
+        await _logout();
+        _redirectToLogin(context);
+        return false;
+      }
+      return true; // 자동 로그인 + 토큰 유효 = 로그인 상태 유지
+    }
+
+    // 현재 세션에서 로그인하지 않았고, 자동 로그인도 비활성화된 경우
+    print('자동 로그인이 비활성화되어 있고 현재 세션에 로그인하지 않았습니다.');
+    await _logout();
+    _redirectToLogin(context);
+    return false;
   }
 
   // 로그아웃 처리 (토큰 및 관련 정보 삭제)
   static Future<void> _logout() async {
+    // 실시간 위치 업데이트 서비스 중지
+    try {
+      final locationService = RealTimeLocationService();
+      await locationService.stopLocationUpdates();
+    } catch (e) {
+      print('위치 업데이트 서비스 중지 오류: $e');
+    }
+
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('token');
     await prefs.remove('user_id');
-    await prefs.remove('remember_me');
+    await prefs.remove('is_logged_in'); // 세션 로그인 상태 제거
+    // remember_me 설정은 유지 (사용자 편의성 향상)
+    print('로그아웃 처리 완료');
   }
 
   // 로그인 페이지로 리디렉션
@@ -90,6 +136,33 @@ class TokenService {
         MaterialPageRoute(builder: (context) => const LoginPage()),
         (route) => false, // 모든 이전 라우트 제거
       );
+    }
+  }
+
+  // 토큰 리프레시 (선택적 기능)
+  static Future<bool> refreshToken() async {
+    // 실제 구현을 위해서는 서버에 요청하여 토큰을 갱신해야 함
+    // 예시 코드만 제공
+    try {
+      print('토큰 갱신 시도');
+      final prefs = await SharedPreferences.getInstance();
+      final oldToken = prefs.getString('token');
+
+      if (oldToken == null) {
+        print('갱신할 토큰이 없습니다.');
+        return false;
+      }
+
+      // 여기서 실제 API 호출을 통해 새 토큰을 발급받아야 함
+      // ...
+
+      // 토큰 저장
+      // await prefs.setString('token', newToken);
+
+      return true;
+    } catch (e) {
+      print('토큰 갱신 실패: $e');
+      return false;
     }
   }
 }

--- a/lib/widgets/navbar.dart
+++ b/lib/widgets/navbar.dart
@@ -1,3 +1,4 @@
+// Enhanced navbar.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tomapto/pages/friends/friends_list_screen.dart';
@@ -6,6 +7,7 @@ import 'package:tomapto/pages/profile/login.dart';
 import 'package:tomapto/pages/profile/profile.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tomapto/services/token_service.dart';
+import 'package:tomapto/services/real_time_location_service.dart';
 
 class BottomNavBar extends StatelessWidget {
   final int currentIndex;
@@ -21,30 +23,63 @@ class BottomNavBar extends StatelessWidget {
   Future<bool> _checkIfUserIsLoggedIn(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
-    final rememberMe = prefs.getBool('remember_me') ?? false;
+    final isLoggedIn = prefs.getBool('is_logged_in') ?? false;
 
-    if (token == null || !rememberMe) {
+    // 토큰이 없으면 로그인되지 않은 상태
+    if (token == null) {
       return false;
     }
 
-    try {
-      if (TokenService.isTokenExpired(token)) {
-        await _logout();
+    // 현재 세션에서 로그인한 경우 (is_logged_in이 true)
+    if (isLoggedIn) {
+      // 토큰 만료 여부만 확인
+      try {
+        if (TokenService.isTokenExpired(token)) {
+          await _logout();
+          return false;
+        }
+        return true; // 현재 세션에서 로그인 상태이고 토큰이 유효하면 로그인 상태
+      } catch (e) {
+        print('토큰 검증 오류: $e');
         return false;
       }
-      return true;
-    } catch (e) {
-      print('토큰 검증 오류: $e');
-      return false;
     }
+
+    // 자동 로그인(remember_me)이 활성화된 경우
+    final rememberMe = prefs.getBool('remember_me') ?? false;
+    if (rememberMe) {
+      // 토큰 만료 확인
+      try {
+        if (TokenService.isTokenExpired(token)) {
+          await _logout();
+          return false;
+        }
+        return true;
+      } catch (e) {
+        print('토큰 검증 오류: $e');
+        return false;
+      }
+    }
+
+    // 로그인 세션도 아니고 자동 로그인도 활성화되지 않은 경우
+    return false;
   }
 
   // 로그아웃 메서드
   Future<void> _logout() async {
+    // 실시간 위치 업데이트 서비스 중지
+    try {
+      final locationService = RealTimeLocationService();
+      await locationService.stopLocationUpdates();
+    } catch (e) {
+      print('위치 업데이트 서비스 중지 오류: $e');
+    }
+
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('token');
     await prefs.remove('user_id');
-    await prefs.remove('remember_me');
+    await prefs.remove('is_logged_in');
+    // remember_me 설정은 유지
   }
 
   // 페이지 이동 처리 메서드
@@ -52,6 +87,9 @@ class BottomNavBar extends StatelessWidget {
     onTap(index);
 
     if (index == currentIndex) return;
+
+    // 네비게이션 전에 로그인 상태 확인 (모든 페이지에 대해)
+    bool isLoggedIn = await _checkIfUserIsLoggedIn(context);
 
     switch (index) {
       case 0:
@@ -67,21 +105,34 @@ class BottomNavBar extends StatelessWidget {
         );
         break;
       case 1:
-        Navigator.pushReplacement(
-          context,
-          PageRouteBuilder(
-            pageBuilder:
-                (context, animation, secondaryAnimation) => FriendScreen(),
-            transitionDuration: Duration.zero,
-            reverseTransitionDuration: Duration.zero,
-          ),
-        );
+        // 친구 페이지로 이동 전에 로그인 상태 확인
+        if (isLoggedIn) {
+          Navigator.pushReplacement(
+            context,
+            PageRouteBuilder(
+              pageBuilder:
+                  (context, animation, secondaryAnimation) => FriendScreen(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ),
+          );
+        } else {
+          // 로그인되지 않은 경우 로그인 페이지로 이동
+          Navigator.pushReplacement(
+            context,
+            PageRouteBuilder(
+              pageBuilder:
+                  (context, animation, secondaryAnimation) => LoginPage(),
+              transitionDuration: Duration.zero,
+              reverseTransitionDuration: Duration.zero,
+            ),
+          );
+        }
         break;
       case 2:
-        // 메뉴 탭
+        // 메뉴 탭 - 로그인 확인 필요시 여기에 추가
         break;
       case 3:
-        bool isLoggedIn = await _checkIfUserIsLoggedIn(context);
         if (isLoggedIn) {
           Navigator.pushReplacement(
             context,


### PR DESCRIPTION
![fewfewfwe](https://github.com/user-attachments/assets/d975afc1-72ec-4d89-b485-58ec30d4cef5)
1. 소켓(알림) 실시간 친구 위치 알림 연결 실패 -> 해결, null을 사용하여 무한대 즉 on/off 기능으로 만듦 (활성화/비활성화)
2. 로그인 앱 유지 안하고 로그인을 하고 친구페이지 이동시 로그인 유지 가능
3. 실시간 위치 이제 DB에 들어감.
4. 친구추가 기능 구현 (이미 친구로 되어있을꺼)
5. 디코 자료에 .env 파일 올려놓을테니 비교후 빠진거 채우기.
6. 부족한 실시간 위치 페이지는 DB 히스토리 테이블 생성후 리팩토링 후 테스트 해보겠음.
